### PR TITLE
Restrict reloading unit to just systemd systems

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,8 @@
 - name: reload unit
   become: true
   command: systemctl daemon-reload
+  when:
+    - ansible_service_mgr == "systemd"
 
 - name: restart docker
   service:


### PR DESCRIPTION
This is actually the work of StudioEtrange in a separate fork that has not been merged back in. This is commit 2e01f70b5f7f833ffedfdcae805c94b0245bb13d on that fork.